### PR TITLE
chore: remove unused dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   "dependencies": {
     "async": "^2.6.1",
     "debug": "^3.1.0",
-    "lodash": "^4.17.10",
     "multiaddr": "^5.0.0",
     "mafmt": "^6.0.0",
     "peer-id": "~0.10.7",


### PR DESCRIPTION
After [#1444](https://github.com/ipfs/js-ipfs/pull/1414), I checked this repo and I noticed that lodash dependency was not being used in this package at all.